### PR TITLE
pendulum 3.1.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "3.0.0" %}
+{% set version = "3.1.0" %}
 
 package:
   name: pendulum
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/p/pendulum/pendulum-{{ version }}.tar.gz
-  sha256: 5d034998dea404ec31fae27af6b22cff1708f830a1ed7353be4d1019bb9f584e
+  sha256: 66f96303560f41d097bee7d2dc98ffca716fbb3a832c4b3062034c2d45865015
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,7 +28,6 @@ requirements:
     - python
     - python-dateutil >=2.6
     - python-tzdata >=2020.1
-    - time-machine >=2.6.0
 
 test:
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,11 +10,9 @@ source:
 
 build:
   number: 0
-  skip: True  # [py<38]
+  skip: True  # [py<39]
   script:
     - {{ PYTHON }} -m pip install . --no-deps -vv --no-build-isolation
-  missing_dso_whitelist:  # [s390x]
-    - "$RPATH/ld64.so.1"  # [s390x]
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,9 +28,7 @@ requirements:
     - python
     - python-dateutil >=2.6
     - python-tzdata >=2020.1
-    - backports.zoneinfo >=0.2.1  # [py<39]
     - time-machine >=2.6.0
-    - importlib-resources >=5.9.0  # [py<39]
 
 test:
   requires:


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-8034](https://anaconda.atlassian.net/browse/PKG-8034)
- [Upstream repository](https://github.com/python-pendulum/pendulum/tree/3.1.0)
- Relevant dependency PRs:
  - `pendulum 3.1.0` ➡️ `flask-appbuilder 4.6.2`

### Explanation of changes:

- Update version
- Update python build skip
- Remove s390x stuff
- Clean up dependencies


[PKG-8034]: https://anaconda.atlassian.net/browse/PKG-8034?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ